### PR TITLE
Fix: - Center HomePage child components on small screen

### DIFF
--- a/src/components/HomePage/CreateMatch.tsx
+++ b/src/components/HomePage/CreateMatch.tsx
@@ -26,12 +26,12 @@ const CreateMatch = ({ serverURL }: CreateMatchProps) => {
   return (
     <div>
       <div className="row flex-center">
-        <div className="col">
+        <div className="col flex-initial">
           <button disabled={clicked} onClick={onClick}>
             Create private match
           </button>
         </div>
-        <div className="col">
+        <div className="col flex-initial">
           <fieldset className="form-group">
             <label className="paper-radio">
               <input

--- a/src/components/HomePage/HelpLink.tsx
+++ b/src/components/HomePage/HelpLink.tsx
@@ -3,12 +3,12 @@ import React from "react";
 
 const HelpLink = () => (
   <div className="row flex-center">
-    <div className="col">
+    <div className="col flex-initial">
       <Link to="/help" className="no-underline">
         <button>How to play</button>
       </Link>
     </div>
-    <div className="col">
+    <div className="col flex-initial">
       <p>Learn the rules!</p>
     </div>
   </div>

--- a/src/components/HomePage/SandboxLink.tsx
+++ b/src/components/HomePage/SandboxLink.tsx
@@ -3,12 +3,12 @@ import React from "react";
 
 const SandboxLink = () => (
   <div className="row flex-center">
-    <div className="col">
+    <div className="col flex-initial">
       <Link to="/sandbox" className="no-underline">
         <button>Sandbox mode</button>
       </Link>
     </div>
-    <div className="col">
+    <div className="col flex-initial">
       <p>Experiment with the game!</p>
     </div>
   </div>

--- a/src/styles/thinktank.css
+++ b/src/styles/thinktank.css
@@ -39,3 +39,9 @@ a.no-underline {
 .col.no-padding {
   padding: 0;
 }
+
+/* Disable 'flex: 0 0 100%' for Paper CSS column
+   @media only screen and (max-width: 768px) */
+.col.flex-initial {
+    flex: initial;
+}


### PR DESCRIPTION
# Issue:
Paper CSS' ```.col``` class has a media query, which causes the following  following child components of ```<HomePage />``` to justify to the left on screens with a width below 768px.
- ```<HelpLink />```
- ```<SandboxLink />```
- ```<CreateMatch />```

Paper CSS media query: ```@media only screen and (max-width: 768px)```
# What has changed:
1. Added CSS rule ```.col.flex-initial``` to ```/src/styles/thinktank.css```
2. Added class ```.flex-initial``` to the following problem components' children having a class of ```.col```:
- ```<HelpLink />```
- ```<SandboxLink />```
- ```<CreateMatch />```
# What reviewer should know
I tried to follow the style of .css rules already in place. I.e. a ```.no-padding``` class overrode Paper CSS' ```.col``` padding rule.
```css
/* Disable padding for a Paper CSS column. */
.col.no-padding {
  padding: 0;
}

/* Disable 'flex: 0 0 100%' for Paper CSS column
   @media only screen and (max-width: 768px) */
.col.flex-initial {
    flex: initial;
}
```
A visual of the changes can be seen in the following screenshots.
### Before
![alt text](https://user-images.githubusercontent.com/44626877/95071759-75a8db80-070a-11eb-9f7a-2806eff1de80.png "Before Screenshot - div's justified to the left")
### After
![alt text](https://user-images.githubusercontent.com/44626877/95071786-7e99ad00-070a-11eb-90ea-afabb89420f1.png "After Screenshot - div's centered")
**Thanks a lot! Love the project!**